### PR TITLE
Add configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@
 .. image:: https://img.shields.io/pypi/pyversions/pyetherscan.svg
     :target: https://pypi.python.org/pypi/pyetherscan
 
+.. image:: https://img.shields.io/pypi/v/pyetherscan.svg
+    :target: https://pypi.python.org/pypi/pyetherscan
+
 
 pyetherscan
 ===========
@@ -23,9 +26,19 @@ make note of your API key. Then install the library by running:
 
     pip install pyetherscan
 
-When using the library, you must set the ``ETHERSCAN_API_KEY``
-environment variable. If you do not set this environment variable, the package
-will default to the ropsten test chain Etherscan API.
+After installation, there are two main ways to set your API key. The first
+is by creating a configuration file named ``.pyetherscan.ini`` and
+saving it in your home directory. The format for this file is as follows:
+
+.. code-block:: none
+
+    [Credentials]
+    ETHERSCAN_API_KEY: YourApiKeyToken
+
+The second is by setting the environment variable ``ETHERSCAN_API_KEY``.
+
+If you do not use either option, the package will connect to the ropsten test
+chain via the Etherscan API by default.
 
 Usage
 =====

--- a/pyetherscan/settings.py
+++ b/pyetherscan/settings.py
@@ -1,4 +1,15 @@
 import os
 
+HOME_DIR = os.path.expanduser('~')
+CONFIG_FILE = '.pyetherscan.ini'
+PATH = os.path.join(HOME_DIR, CONFIG_FILE)
 TESTING_API_KEY = 'YourApiKeyToken'
-ETHERSCAN_API_KEY = os.environ.get('ETHERSCAN_API_KEY', TESTING_API_KEY)
+
+if os.path.isfile(PATH):
+    from configparser import ConfigParser
+    config = ConfigParser()
+    config.read(PATH)
+    ETHERSCAN_API_KEY = config['Credentials']['ETHERSCAN_API_KEY']
+
+else:
+    ETHERSCAN_API_KEY = os.environ.get('ETHERSCAN_API_KEY', TESTING_API_KEY)


### PR DESCRIPTION
This resolves #22 by adding the option to set API credentials via a configuration file.