### PR TITLE
Import errors and data updates

### DIFF
--- a/pyetherscan/__init__.py
+++ b/pyetherscan/__init__.py
@@ -1,0 +1,81 @@
+"""
+Package containing core pyetherscan functionality.
+"""
+
+from pyetherscan import client
+from pyetherscan.client import Client
+
+from pyetherscan import error
+from pyetherscan.error import (
+    EtherscanDataError,
+    EtherscanInitializationError,
+    EtherscanConnectionError,
+    EtherscanRequestError,
+    EtherscanAddressError,
+    EtherscanContractError,
+    EtherscanTransactionError,
+    EtherscanBlockError,
+    EtherscanEventLogError,
+    EtherscanGethProxyError,
+    EtherscanWebsocketError,
+    EtherscanTokenError,
+    EtherscanStatsError,
+)
+
+from pyetherscan import ethereum
+from pyetherscan.ethereum import (
+    Transaction,
+    Address,
+    Block,
+    Token,
+)
+
+from pyetherscan import response
+from pyetherscan.response import (
+    SingleAddressBalanceResponse,
+    MultiAddressBalanceResponse,
+    TransactionsByAddressResponse,
+    TransactionsByHashResponse,
+    BlocksMinedByAddressResponse,
+    ContractABIByAddressResponse,
+    ContractStatusResponse,
+    TokenSupplyResponse,
+    TokenAccountBalanceResponse,
+    BlockRewardsResponse,
+)
+
+
+__all__ = [
+    'client',
+    'Client',
+    'error',
+    'EtherscanDataError',
+    'EtherscanInitializationError',
+    'EtherscanConnectionError',
+    'EtherscanRequestError',
+    'EtherscanAddressError',
+    'EtherscanContractError',
+    'EtherscanTransactionError',
+    'EtherscanBlockError',
+    'EtherscanEventLogError',
+    'EtherscanGethProxyError',
+    'EtherscanWebsocketError',
+    'EtherscanTokenError',
+    'EtherscanStatsError',
+    'ethereum',
+    'Transaction',
+    'Address',
+    'Block',
+    'Token',
+    'response',
+    'SingleAddressBalanceResponse',
+    'MultiAddressBalanceResponse',
+    'TransactionsByAddressResponse',
+    'TransactionsByHashResponse',
+    'BlocksMinedByAddressResponse',
+    'ContractABIByAddressResponse',
+    'ContractStatusResponse',
+    'TokenSupplyResponse',
+    'TokenAccountBalanceResponse',
+    'BlockRewardsResponse',
+]

--- a/pyetherscan/client.py
+++ b/pyetherscan/client.py
@@ -11,7 +11,9 @@ def check_exception_for_retry(exception):
     """
     Prevent retrying if an etherscan response status is not 1.
     """
-    return not isinstance(exception, error.EtherscanDataError)
+    data_error = isinstance(exception, error.EtherscanDataError)
+    request_error = isinstance(exception, error.EtherscanRequestError)
+    return not data_error and not request_error
 
 
 RETRY_KWARGS = {

--- a/pyetherscan/ethereum.py
+++ b/pyetherscan/ethereum.py
@@ -232,6 +232,9 @@ class TransactionContainer(object):
     """
 
     def __init__(self, transaction_list):
+        if not isinstance(transaction_list, list):
+            raise TypeError('transaction_list must be of type list, '
+                            'not {type}'.format(type=type(transaction_list)))
         self.transaction_list = transaction_list
 
     def __iter__(self):
@@ -322,7 +325,9 @@ class Address(object):
             address=self.address,
             internal=True
         )
-        self._transactions = normal.transactions + internal.transactions
+        txns = normal.transactions + internal.transactions
+        self._transactions = txns or []
+        return self._transactions
 
     @property
     def _raw_transactions(self):
@@ -346,7 +351,7 @@ class Address(object):
 
     def _retrieve_block_list(self):
         response = self.client.get_blocks_mined_by_address(self.address)
-        self._block_list = response.blocks
+        self._block_list = response.blocks or []
         return self._block_list
 
     @property

--- a/pyetherscan/response.py
+++ b/pyetherscan/response.py
@@ -50,11 +50,13 @@ class EtherscanResponse(object):
                 'reason: {reason}'.format(reason=resp.reason)
             )
 
-        if self.status not in [1, '1']:
+        result = self.etherscan_response.get('result')
+        bad_data = self.message == 'NOTOK' or result == 'Error!'
+        if bad_data:
             raise error.EtherscanDataError(
                 '{message}. result={result}'.format(
                     message=self.message,
-                    result=self.etherscan_response.get('result')
+                    result=result
                 )
             )
 

--- a/pyetherscan/response.py
+++ b/pyetherscan/response.py
@@ -4,12 +4,15 @@ A module used to define API-specific response objects. All Etherscan API request
 See :doc:`/response` for an overview.
 """
 import json
-try:
-    from json.decoder import JSONDecodeError
-except AttributeError:
-    from json import JSONDecodeError
 
 from . import error
+
+try:
+    from json.decoder import JSONDecodeError
+except (AttributeError, ImportError):
+    # In python 2.x there is no JSONDecodeError, the json module
+    # simply throws a ValueError
+    JSONDecodeError = ValueError
 
 
 class EtherscanResponse(object):

--- a/pyetherscan/response.py
+++ b/pyetherscan/response.py
@@ -4,6 +4,10 @@ A module used to define API-specific response objects. All Etherscan API request
 See :doc:`/response` for an overview.
 """
 import json
+try:
+    from json.decoder import JSONDecodeError
+except AttributeError:
+    from json import JSONDecodeError
 
 from . import error
 
@@ -41,7 +45,7 @@ class EtherscanResponse(object):
         # Attempt to parse response body
         try:
             self.etherscan_response = json.loads(resp.text)
-        except (AttributeError, json.decoder.JSONDecodeError):
+        except (AttributeError, JSONDecodeError):
             raise error.EtherscanRequestError(
                 'Invalid request: \n{request}'.format(
                     request=resp

--- a/pyetherscan/response.py
+++ b/pyetherscan/response.py
@@ -25,31 +25,33 @@ class EtherscanResponse(object):
     """
 
     def __init__(self, resp):
+
+        # Check for rate limit errors
         if resp.status_code == 403:
             raise error.EtherscanRequestError(
                 'Rate limit reached.'
             )
 
+        # Ensure a valid response code was received
+        if resp.status_code not in [200, 201]:
+            raise error.EtherscanRequestError(
+                'reason: {reason}'.format(reason=resp.reason)
+            )
+
+        # Attempt to parse response body
         try:
             self.etherscan_response = json.loads(resp.text)
-        except AttributeError:
+        except (AttributeError, json.decoder.JSONDecodeError):
             raise error.EtherscanRequestError(
                 'Invalid request: \n{request}'.format(
                     request=resp
                 )
             )
         else:
-            self.response_object = resp
-            self.response_status_code = self.response_object.status_code
-            self.status = self.etherscan_response.get('status')
             self.message = self.etherscan_response.get('message')
-            self.parse_response()
+            self.status = self.etherscan_response.get('status')
 
-        if resp.status_code not in [200, 201]:
-            raise error.EtherscanRequestError(
-                'reason: {reason}'.format(reason=resp.reason)
-            )
-
+        # Parse API message to check for API errors
         result = self.etherscan_response.get('result')
         bad_data = self.message == 'NOTOK' or result == 'Error!'
         if bad_data:
@@ -59,6 +61,11 @@ class EtherscanResponse(object):
                     result=result
                 )
             )
+
+        # Finish parsing response object
+        self.response_object = resp
+        self.response_status_code = resp.status_code
+        self.parse_response()
 
     def parse_response(self):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,12 +31,12 @@ class TestInitialization(BaseClientTestCase):
 class TestAccountEndpoint(BaseClientTestCase):
 
     def test_get_single_balance(self):
-        expected_bal = 7.459976043829251e+23
+        expected_bal = 745997704382925139479303.0
 
         expected_response = {
             u'status': u'1',
             u'message': u'OK',
-            u'result': u'745997604382925139479303'
+            u'result': u'745997704382925139479303'
         }
         address = '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae'
         result = self.client.get_single_balance(address)

--- a/tests/test_ethereum.py
+++ b/tests/test_ethereum.py
@@ -15,7 +15,7 @@ class TestAddressObject(BaseEthereumTestCase):
     def test_retrieve_balance(self):
         _address = '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae'
         address = ethereum.Address(address=_address)
-        self.assertEqual(address.balance, 7.459976043829251e+23)
+        self.assertEqual(address.balance, 745997704382925139479303.0)
 
         with self.assertRaises(error.EtherscanInitializationError):
             _bad_address = 5

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,52 @@
+"""
+Tests related to response objects.
+"""
+import unittest
+import requests
+
+from pyetherscan import client, response, error
+
+
+class FakeResponse(requests.Response):
+    """Fake instance of a Response object"""
+
+    def __init__(self, status_code, text):
+        requests.Response.__init__(self)
+
+        self.status_code = status_code
+        self._text = text
+
+    @property
+    def text(self):
+        return self._text
+
+
+class BaseResponseTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.client = client.Client()
+
+    def base_request_error(self, code, text):
+        """Abstract testing for request errors"""
+        resp = FakeResponse(code, text)
+        with self.assertRaises(error.EtherscanRequestError):
+            response.SingleAddressBalanceResponse(resp)
+
+
+class TestInitializationResponses(BaseResponseTestCase):
+
+    def test_rate_limit_error(self):
+        self.base_request_error(403, '')
+
+    def test_invalid_request(self):
+        self.base_request_error(200, '')
+
+    def test_bad_code_error(self):
+        self.base_request_error(405, '')
+
+    def test_data_error(self):
+        text = "{\"message\":\"NOTOK\", \"result\":\"Error!\"}"
+        resp = FakeResponse(200, text)
+
+        with self.assertRaises(error.EtherscanDataError):
+            response.SingleAddressBalanceResponse(resp)


### PR DESCRIPTION
This PR adds top level imports to the `__init__` file to avoid explicit imports when installing via pip. For example:

`from pyetherscan.client import Client`

Now becomes

`from pyetherscan import Client`

or

`import pyetherscan; client = pyetherscan.Client()`

Additionally, the data exception has been updated to allow empty result sets. It will only raise if there is truly a problem with the data.

This effectively resolves #28 and resolves #26