### PR TITLE
Fix python versioning errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.1] - 2017-07-18
+### Changed
+- Fixed python version errors in the `settings.py` file.
+
 ## [0.1.0] - 2017-07-18
 ### Added
 - The ability to set `ETHERSCAN_API_KEY` using a configuration file (thanks
@@ -35,7 +39,8 @@ to @veox).
 - Added path identification support for both python 2 and 3 in the `setup.py`
   file to identify the `long_descripton` variable (previously failed for py2).
 
-[Unreleased]: https://github.com/Marto32/pyetherscan/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/Marto32/pyetherscan/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/Marto32/pyetherscan/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/Marto32/pyetherscan/compare/0.0.2...0.1.0
 [0.0.2]: https://github.com/Marto32/pyetherscan/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/Marto32/pyetherscan/compare/0.0.0...0.0.1

--- a/pyetherscan/client.py
+++ b/pyetherscan/client.py
@@ -2,6 +2,7 @@
 Library for connecting to the Etherscan API using a self contained client.
 """
 import requests
+import sys
 
 from retrying import retry
 from . import error, response, settings
@@ -100,7 +101,11 @@ class Client(object):
         self.timeout = timeout
         self.apikey = apikey
 
-        if not isinstance(self.apikey, str):
+        if sys.version_info[0] < 3:
+            accepted_types = (str, unicode)
+        else:
+            accepted_types = str
+        if not isinstance(self.apikey, accepted_types):
             raise error.EtherscanInitializationError(
                 'You must supply an API key.'
             )

--- a/pyetherscan/settings.py
+++ b/pyetherscan/settings.py
@@ -6,7 +6,11 @@ PATH = os.path.join(HOME_DIR, CONFIG_FILE)
 TESTING_API_KEY = 'YourApiKeyToken'
 
 if os.path.isfile(PATH):
-    from configparser import ConfigParser
+    try:
+        from configparser import ConfigParser
+    except ImportError:
+        # Handle python 2.7 code
+        import ConfigParser
     config = ConfigParser()
     config.read(PATH)
     ETHERSCAN_API_KEY = config['Credentials']['ETHERSCAN_API_KEY']

--- a/setup.py
+++ b/setup.py
@@ -16,18 +16,19 @@ else:
 setup(
     name='pyetherscan',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    version='0.1.0',
+    version='0.1.1',
     description='An unofficial wrapper for the Etherscan.io API',
     long_description=long_description,
     author='Michael Martorella',
     author_email='michaelmartorella@gmail.com',
     url='https://github.com/Marto32/pyetherscan',
-    download_url='https://github.com/Marto32/pyetherscan/archive/0.1.0.tar.gz',
+    download_url='https://github.com/Marto32/pyetherscan/archive/0.1.1.tar.gz',
     keywords=['ethereum', 'blockchain', 'etherscan'],
     license='MIT License',
     install_requires=[
         'requests',
         'retrying',
+        'configparser',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     install_requires=[
         'requests',
         'retrying',
-        'configparser',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
There were some version and import errors in the `setup.py` and `settings.py` files.

Namely that python 2 doesn't have the base `configparser` module.

This corrects those.